### PR TITLE
upd: diamond companies info

### DIFF
--- a/src/components/Companies/CompanyInfo/index.tsx
+++ b/src/components/Companies/CompanyInfo/index.tsx
@@ -54,21 +54,23 @@ const CompanyInfo: React.FC<CompanyInfoProps> = ({
           </div>
         </div>
       )}
-      <div className="px-10">
-        <h1 className="mb-4 mt-8 text-left text-lg font-bold uppercase text-black sm:text-lg md:text-xl lg:text-2xl">
-          Interesses
-        </h1>
-        <div className="flex w-full flex-wrap gap-4">
-          {interests?.map((interest) => (
-            <div
-              key={interest}
-              className="relative rounded-xl bg-slate-200 px-3 py-1 text-black"
-            >
-              {interest}
-            </div>
-          ))}
-        </div>
-      </div>
+	  {(interests == undefined || interests?.length > 0) && (
+		<div className="px-10">
+        	<h1 className="mb-4 mt-8 text-left text-lg font-bold uppercase text-black sm:text-lg md:text-xl lg:text-2xl">
+				Interesses
+        	</h1>
+        	<div className="flex w-full flex-wrap gap-4">
+          		{interests?.map((interest) => (
+            		<div
+              			key={interest}
+              			className="relative rounded-xl bg-slate-200 px-3 py-1 text-black"
+            		>
+              			{interest}
+            		</div>
+          		))}
+        	</div>
+		</div>
+	  )}
     </section>
   );
 };

--- a/src/utils/DiamondCompanies.tsx
+++ b/src/utils/DiamondCompanies.tsx
@@ -82,6 +82,21 @@ export const DiamondCompanies: CompanyProps[] = [
       instagramLink: "https://www.instagram.com/convatecostomiaportugal/?hl=pt",
       linkedinLink: "https://www.linkedin.com/company/convatec/?trk=public_profile_topcard-current-company&originalSubdomain=pt",
       videoHref: "https://www.youtube.com/watch?v=_KY96eNgrZ8",
+      facts: [
+        {
+          iconSrc: Trophy,
+          description:
+            "Está listada na London Stock Exchange",
+        },
+        {
+          iconSrc: Archive,
+          description: "Fundada em 1978",
+        },
+        {
+          iconSrc: Chart,
+          description: "Produtos e serviços vendidos em mais de 100 países",
+        },
+      ],
     }
   },
   {


### PR DESCRIPTION
# Changes

In this pull request:
- Added more info for some diamond companies
- Removed interests label when there are no interests

## Before

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/9e4f3049-05c2-4ed4-bed1-96596b6e4d49">

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/4009ed71-4c78-4b76-be3e-30e83a588890">


## After

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/4d4b4a90-6526-4f9a-9bc4-835622cbe888">

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/9906c4a7-c762-414c-a000-4b68643265c8">

